### PR TITLE
SC fork that only crawls SC packages

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,5 +1,5 @@
 {
-	"ImportPath": "github.com/golang/gddo",
+	"ImportPath": "github.com/SafetyCulture/gddo",
 	"GoVersion": "go1.10",
 	"GodepVersion": "v80",
 	"Packages": [

--- a/database/database.go
+++ b/database/database.go
@@ -54,8 +54,8 @@ import (
 	"google.golang.org/appengine/remote_api"
 	"google.golang.org/appengine/search"
 
-	"github.com/golang/gddo/doc"
-	"github.com/golang/gddo/gosrc"
+	"github.com/SafetyCulture/gddo/doc"
+	"github.com/SafetyCulture/gddo/gosrc"
 )
 
 type Database struct {

--- a/database/database_test.go
+++ b/database/database_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/garyburd/redigo/redis"
 	"github.com/google/go-cmp/cmp"
 
-	"github.com/golang/gddo/doc"
+	"github.com/SafetyCulture/gddo/doc"
 )
 
 func newDB(t *testing.T) *Database {

--- a/database/index.go
+++ b/database/index.go
@@ -12,8 +12,8 @@ import (
 	"strings"
 	"unicode"
 
-	"github.com/golang/gddo/doc"
-	"github.com/golang/gddo/gosrc"
+	"github.com/SafetyCulture/gddo/doc"
+	"github.com/SafetyCulture/gddo/gosrc"
 )
 
 func isStandardPackage(path string) bool {

--- a/database/index_test.go
+++ b/database/index_test.go
@@ -10,7 +10,7 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/golang/gddo/doc"
+	"github.com/SafetyCulture/gddo/doc"
 	"github.com/google/go-cmp/cmp"
 )
 

--- a/database/indexae.go
+++ b/database/indexae.go
@@ -18,7 +18,7 @@ import (
 
 	"google.golang.org/appengine/search"
 
-	"github.com/golang/gddo/doc"
+	"github.com/SafetyCulture/gddo/doc"
 )
 
 func (p *Package) Load(fields []search.Field, meta *search.DocumentMetadata) error {

--- a/database/indexae_test.go
+++ b/database/indexae_test.go
@@ -14,7 +14,7 @@ import (
 	"google.golang.org/appengine/aetest"
 	"google.golang.org/appengine/search"
 
-	"github.com/golang/gddo/doc"
+	"github.com/SafetyCulture/gddo/doc"
 )
 
 var pdoc = &doc.Package{

--- a/doc/builder.go
+++ b/doc/builder.go
@@ -22,7 +22,7 @@ import (
 	"unicode"
 	"unicode/utf8"
 
-	"github.com/golang/gddo/gosrc"
+	"github.com/SafetyCulture/gddo/gosrc"
 )
 
 func startsWithUppercase(s string) bool {

--- a/doc/get.go
+++ b/doc/get.go
@@ -13,7 +13,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/golang/gddo/gosrc"
+	"github.com/SafetyCulture/gddo/gosrc"
 )
 
 func Get(ctx context.Context, client *http.Client, importPath string, etag string) (*Package, error) {

--- a/doc/print.go
+++ b/doc/print.go
@@ -18,8 +18,8 @@ import (
 	"os"
 
 	"github.com/davecgh/go-spew/spew"
-	"github.com/golang/gddo/doc"
-	"github.com/golang/gddo/gosrc"
+	"github.com/SafetyCulture/gddo/doc"
+	"github.com/SafetyCulture/gddo/gosrc"
 )
 
 var (

--- a/doc/vet.go
+++ b/doc/vet.go
@@ -13,7 +13,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/golang/gddo/gosrc"
+	"github.com/SafetyCulture/gddo/gosrc"
 )
 
 // This list of deprecated exports is used to find code that has not been

--- a/gddo-admin/block.go
+++ b/gddo-admin/block.go
@@ -10,7 +10,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/golang/gddo/database"
+	"github.com/SafetyCulture/gddo/database"
 )
 
 var blockCommand = &command{

--- a/gddo-admin/crawl.go
+++ b/gddo-admin/crawl.go
@@ -14,7 +14,7 @@ import (
 	"strings"
 
 	"github.com/garyburd/redigo/redis"
-	"github.com/golang/gddo/database"
+	"github.com/SafetyCulture/gddo/database"
 )
 
 var crawlCommand = &command{

--- a/gddo-admin/dangle.go
+++ b/gddo-admin/dangle.go
@@ -11,8 +11,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/golang/gddo/database"
-	"github.com/golang/gddo/gosrc"
+	"github.com/SafetyCulture/gddo/database"
+	"github.com/SafetyCulture/gddo/gosrc"
 )
 
 var dangleCommand = &command{

--- a/gddo-admin/delete.go
+++ b/gddo-admin/delete.go
@@ -11,7 +11,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/golang/gddo/database"
+	"github.com/SafetyCulture/gddo/database"
 )
 
 var deleteCommand = &command{

--- a/gddo-admin/popular.go
+++ b/gddo-admin/popular.go
@@ -11,7 +11,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/golang/gddo/database"
+	"github.com/SafetyCulture/gddo/database"
 )
 
 var (

--- a/gddo-admin/reindex.go
+++ b/gddo-admin/reindex.go
@@ -12,8 +12,8 @@ import (
 	"os"
 	"time"
 
-	"github.com/golang/gddo/database"
-	"github.com/golang/gddo/doc"
+	"github.com/SafetyCulture/gddo/database"
+	"github.com/SafetyCulture/gddo/doc"
 )
 
 var reindexCommand = &command{

--- a/gddo-admin/stats.go
+++ b/gddo-admin/stats.go
@@ -12,7 +12,7 @@ import (
 	"os"
 	"sort"
 
-	"github.com/golang/gddo/database"
+	"github.com/SafetyCulture/gddo/database"
 )
 
 var statsCommand = &command{

--- a/gddo-server/background.go
+++ b/gddo-server/background.go
@@ -13,7 +13,7 @@ import (
 
 	"cloud.google.com/go/trace"
 
-	"github.com/golang/gddo/gosrc"
+	"github.com/SafetyCulture/gddo/gosrc"
 )
 
 func (s *server) doCrawl(ctx context.Context) error {

--- a/gddo-server/client.go
+++ b/gddo-server/client.go
@@ -18,7 +18,7 @@ import (
 	"github.com/gregjones/httpcache/memcache"
 	"github.com/spf13/viper"
 
-	"github.com/golang/gddo/httputil"
+	"github.com/SafetyCulture/gddo/httputil"
 )
 
 func newHTTPClient(v *viper.Viper) *http.Client {

--- a/gddo-server/config.go
+++ b/gddo-server/config.go
@@ -12,7 +12,7 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 
-	"github.com/golang/gddo/log"
+	"github.com/SafetyCulture/gddo/log"
 )
 
 const (
@@ -153,7 +153,7 @@ func buildFlags() *pflag.FlagSet {
 	flags.StringP("config", "c", "", "path to motd config file")
 	flags.String(ConfigProject, "", "Google Cloud Platform project used for Google services")
 	flags.Float64(ConfigRobotThreshold, 100, "Request counter threshold for robots.")
-	flags.String(ConfigAssetsDir, filepath.Join(defaultBase("github.com/golang/gddo/gddo-server"), "assets"), "Base directory for templates and static files.")
+	flags.String(ConfigAssetsDir, filepath.Join(defaultBase("github.com/SafetyCulture/gddo/gddo-server"), "assets"), "Base directory for templates and static files.")
 	flags.Duration(ConfigGetTimeout, 8*time.Second, "Time to wait for package update from the VCS.")
 	flags.Duration(ConfigFirstGetTimeout, 5*time.Second, "Time to wait for first fetch of package from the VCS.")
 	flags.Duration(ConfigMaxAge, 24*time.Hour, "Update package documents older than this age.")

--- a/gddo-server/crawl.go
+++ b/gddo-server/crawl.go
@@ -17,8 +17,8 @@ import (
 
 	"cloud.google.com/go/pubsub"
 
-	"github.com/golang/gddo/doc"
-	"github.com/golang/gddo/gosrc"
+	"github.com/SafetyCulture/gddo/doc"
+	"github.com/SafetyCulture/gddo/gosrc"
 )
 
 var (

--- a/gddo-server/crawl.go
+++ b/gddo-server/crawl.go
@@ -22,7 +22,8 @@ import (
 )
 
 var (
-	testdataPat = regexp.MustCompile(`/testdata(?:/|$)`)
+	testdataPat      = regexp.MustCompile(`/testdata(?:/|$)`)
+	safetyCulturePat = regexp.MustCompile(`github.com/SafetyCulture/.*`)
 )
 
 // crawlNote is a message sent to Pub/Sub when a crawl occurs.
@@ -79,6 +80,9 @@ func (s *server) crawlDoc(ctx context.Context, source string, importPath string,
 	} else if testdataPat.MatchString(importPath) {
 		pdoc = nil
 		err = gosrc.NotFoundError{Message: "testdata."}
+	} else if !safetyCulturePat.MatchString(importPath) && (source == "crawl" || source == "new") {
+		pdoc = nil
+		err = gosrc.NotFoundError{Message: "not SafetyCulture."}
 	} else {
 		var pdocNew *doc.Package
 		pdocNew, err = doc.Get(ctx, s.httpClient, importPath, etag)

--- a/gddo-server/graph.go
+++ b/gddo-server/graph.go
@@ -13,8 +13,8 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/golang/gddo/database"
-	"github.com/golang/gddo/doc"
+	"github.com/SafetyCulture/gddo/database"
+	"github.com/SafetyCulture/gddo/doc"
 )
 
 func renderGraph(pdoc *doc.Package, pkgs []database.Package, edges [][2]int) ([]byte, error) {

--- a/gddo-server/logging.go
+++ b/gddo-server/logging.go
@@ -14,7 +14,7 @@ import (
 	"time"
 
 	"cloud.google.com/go/logging"
-	"github.com/golang/gddo/database"
+	"github.com/SafetyCulture/gddo/database"
 )
 
 // newGCELogger returns a handler that wraps h but logs each request

--- a/gddo-server/main.go
+++ b/gddo-server/main.go
@@ -33,11 +33,11 @@ import (
 	"cloud.google.com/go/trace"
 	"github.com/spf13/viper"
 
-	"github.com/golang/gddo/database"
-	"github.com/golang/gddo/doc"
-	"github.com/golang/gddo/gosrc"
-	"github.com/golang/gddo/httputil"
-	"github.com/golang/gddo/internal/health"
+	"github.com/SafetyCulture/gddo/database"
+	"github.com/SafetyCulture/gddo/doc"
+	"github.com/SafetyCulture/gddo/gosrc"
+	"github.com/SafetyCulture/gddo/httputil"
+	"github.com/SafetyCulture/gddo/internal/health"
 )
 
 const (

--- a/gddo-server/play.go
+++ b/gddo-server/play.go
@@ -13,7 +13,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/golang/gddo/doc"
+	"github.com/SafetyCulture/gddo/doc"
 )
 
 func findExamples(pdoc *doc.Package, export, method string) []*doc.Example {

--- a/gddo-server/template.go
+++ b/gddo-server/template.go
@@ -27,9 +27,9 @@ import (
 
 	"github.com/spf13/viper"
 
-	"github.com/golang/gddo/doc"
-	"github.com/golang/gddo/gosrc"
-	"github.com/golang/gddo/httputil"
+	"github.com/SafetyCulture/gddo/doc"
+	"github.com/SafetyCulture/gddo/gosrc"
+	"github.com/SafetyCulture/gddo/httputil"
 )
 
 type flashMessage struct {

--- a/gosrc/print.go
+++ b/gosrc/print.go
@@ -19,8 +19,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/golang/gddo/gosrc"
-	"github.com/golang/gddo/httputil"
+	"github.com/SafetyCulture/gddo/gosrc"
+	"github.com/SafetyCulture/gddo/httputil"
 )
 
 var (

--- a/httputil/negotiate.go
+++ b/httputil/negotiate.go
@@ -7,7 +7,7 @@
 package httputil
 
 import (
-	"github.com/golang/gddo/httputil/header"
+	"github.com/SafetyCulture/gddo/httputil/header"
 	"net/http"
 	"strings"
 )

--- a/httputil/negotiate_test.go
+++ b/httputil/negotiate_test.go
@@ -7,7 +7,7 @@
 package httputil_test
 
 import (
-	"github.com/golang/gddo/httputil"
+	"github.com/SafetyCulture/gddo/httputil"
 	"net/http"
 	"testing"
 )

--- a/httputil/static.go
+++ b/httputil/static.go
@@ -11,7 +11,7 @@ import (
 	"crypto/sha1"
 	"errors"
 	"fmt"
-	"github.com/golang/gddo/httputil/header"
+	"github.com/SafetyCulture/gddo/httputil/header"
 	"io"
 	"io/ioutil"
 	"mime"

--- a/httputil/static_test.go
+++ b/httputil/static_test.go
@@ -18,7 +18,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/gddo/httputil"
+	"github.com/SafetyCulture/gddo/httputil"
 	"github.com/google/go-cmp/cmp"
 )
 

--- a/lintapp/main.go
+++ b/lintapp/main.go
@@ -25,8 +25,8 @@ import (
 	"google.golang.org/appengine/log"
 	"google.golang.org/appengine/urlfetch"
 
-	"github.com/golang/gddo/gosrc"
-	"github.com/golang/gddo/httputil"
+	"github.com/SafetyCulture/gddo/gosrc"
+	"github.com/SafetyCulture/gddo/httputil"
 
 	"github.com/golang/lint"
 )

--- a/talksapp/main.go
+++ b/talksapp/main.go
@@ -24,8 +24,8 @@ import (
 	"google.golang.org/appengine/memcache"
 	"google.golang.org/appengine/urlfetch"
 
-	"github.com/golang/gddo/gosrc"
-	"github.com/golang/gddo/httputil"
+	"github.com/SafetyCulture/gddo/gosrc"
+	"github.com/SafetyCulture/gddo/httputil"
 
 	"golang.org/x/tools/present"
 )

--- a/talksapp/main_test.go
+++ b/talksapp/main_test.go
@@ -20,7 +20,7 @@ import (
 	"google.golang.org/appengine/aetest"
 	"google.golang.org/appengine/memcache"
 
-	"github.com/golang/gddo/gosrc"
+	"github.com/SafetyCulture/gddo/gosrc"
 )
 
 const importPath = "github.com/user/repo/path/to/presentation.slide"


### PR DESCRIPTION
Prevent other packages from being crawled. They can still be fetched directly, this just limits how much we hit the GitHub API and how much data we have to cache in redis. 