### PR TITLE
Adds support for --statis-path (STATIC_PATH) to support a different URI for static assets

### DIFF
--- a/gddo-server/config.go
+++ b/gddo-server/config.go
@@ -24,7 +24,7 @@ const (
 	githubClientIDEnvVar     = "GITHUB_CLIENT_ID"
 	githubClientSecretEnvVar = "GITHUB_CLIENT_SECRET"
 
-	getStaticPathEnvVar = "STATIC_PATH"
+	getStaticURLEnvVar = "STATIC_URL"
 )
 
 const (
@@ -35,7 +35,7 @@ const (
 	ConfigAssetsDir         = "assets"
 	ConfigRobotThreshold    = "robot"
 	ConfigGCELogName        = "gce_log_name"
-	ConfigStaticPath        = "static_path"
+	ConfigStaticURL         = "static_url"
 
 	// Database Config
 	ConfigDBServer      = "db-server"
@@ -114,7 +114,7 @@ func loadConfig(ctx context.Context, args []string) (*viper.Viper, error) {
 	v.BindEnv(ConfigGithubToken, githubTokenEnvVar)
 	v.BindEnv(ConfigGithubClientID, githubClientIDEnvVar)
 	v.BindEnv(ConfigGithubClientSecret, githubClientSecretEnvVar)
-	v.BindEnv(ConfigStaticPath, getStaticPathEnvVar)
+	v.BindEnv(ConfigStaticURL, getStaticURLEnvVar)
 
 	// Read from config.
 	if err := readViperConfig(ctx, v); err != nil {
@@ -177,7 +177,7 @@ func buildFlags() *pflag.FlagSet {
 	flags.String(ConfigGAERemoteAPI, "", "Remoteapi endpoint for App Engine Search. Defaults to serviceproxy-dot-${project}.appspot.com.")
 	flags.Float64(ConfigTraceSamplerFraction, 0.1, "Fraction of the requests sampled by the trace API.")
 	flags.Float64(ConfigTraceSamplerMaxQPS, 5, "Max number of requests sampled every second by the trace API.")
-	flags.String(ConfigStaticPath, "", "Custom Static Path (URI) used in templates for static resources")
+	flags.String(ConfigStaticURL, "", "Custom Static URL used in templates for static resources")
 
 	return flags
 }

--- a/gddo-server/config.go
+++ b/gddo-server/config.go
@@ -23,6 +23,8 @@ const (
 	githubTokenEnvVar        = "GITHUB_TOKEN"
 	githubClientIDEnvVar     = "GITHUB_CLIENT_ID"
 	githubClientSecretEnvVar = "GITHUB_CLIENT_SECRET"
+
+	getStaticPathEnvVar = "STATIC_PATH"
 )
 
 const (
@@ -33,6 +35,7 @@ const (
 	ConfigAssetsDir         = "assets"
 	ConfigRobotThreshold    = "robot"
 	ConfigGCELogName        = "gce_log_name"
+	ConfigStaticPath        = "static_path"
 
 	// Database Config
 	ConfigDBServer      = "db-server"
@@ -111,6 +114,7 @@ func loadConfig(ctx context.Context, args []string) (*viper.Viper, error) {
 	v.BindEnv(ConfigGithubToken, githubTokenEnvVar)
 	v.BindEnv(ConfigGithubClientID, githubClientIDEnvVar)
 	v.BindEnv(ConfigGithubClientSecret, githubClientSecretEnvVar)
+	v.BindEnv(ConfigStaticPath, getStaticPathEnvVar)
 
 	// Read from config.
 	if err := readViperConfig(ctx, v); err != nil {
@@ -173,6 +177,7 @@ func buildFlags() *pflag.FlagSet {
 	flags.String(ConfigGAERemoteAPI, "", "Remoteapi endpoint for App Engine Search. Defaults to serviceproxy-dot-${project}.appspot.com.")
 	flags.Float64(ConfigTraceSamplerFraction, 0.1, "Fraction of the requests sampled by the trace API.")
 	flags.Float64(ConfigTraceSamplerMaxQPS, 5, "Max number of requests sampled every second by the trace API.")
+	flags.String(ConfigStaticPath, "", "Custom Static Path (URI) used in templates for static resources")
 
 	return flags
 }

--- a/gddo-server/template.go
+++ b/gddo-server/template.go
@@ -553,7 +553,7 @@ func parseTemplates(dir string, cb *httputil.CacheBusters, v *viper.Viper) (temp
 		"relativePath":      relativePathFn,
 		"sidebarEnabled":    func() bool { return v.GetBool(ConfigSidebar) },
 		"staticPath": func(p string) string {
-			return strings.Join([]string{v.GetString(ConfigStaticPath), cb.AppendQueryParam(p, "v")}, "")
+			return strings.Join([]string{v.GetString(ConfigStaticURL), cb.AppendQueryParam(p, "v")}, "")
 		},
 	}
 	for _, set := range htmlSets {

--- a/gddo-server/template.go
+++ b/gddo-server/template.go
@@ -552,7 +552,9 @@ func parseTemplates(dir string, cb *httputil.CacheBusters, v *viper.Viper) (temp
 		"noteTitle":         noteTitleFn,
 		"relativePath":      relativePathFn,
 		"sidebarEnabled":    func() bool { return v.GetBool(ConfigSidebar) },
-		"staticPath":        func(p string) string { return cb.AppendQueryParam(p, "v") },
+		"staticPath": func(p string) string {
+			return strings.Join([]string{v.GetString(ConfigStaticPath), cb.AppendQueryParam(p, "v")}, "")
+		},
 	}
 	for _, set := range htmlSets {
 		templateName := set[0]


### PR DESCRIPTION
This hopefully resolves an issue we have internally with our hosted godoc:

https://internal-eks01.us.prd.scinfra.com/godoc/

Where we currently are unable to serve any of the static resources;

```
Failed to load resource: the server responded with a status of 404 ()
```

The URI(s) currently being attempted currently look like this:

* https://internal-eks01.us.prd.scinfra.com/-/jquery-2.0.3.min.js?v=fbf9c77d0c4e3c34a485980c1e5316b6212160c8

Which our ingress controller promptly refuses to serve up :)