### PR TITLE
Changes StaticURL to BaseURL and create dynamicPath and staticPath functions for templates

### DIFF
--- a/gddo-server/assets/templates/common.html
+++ b/gddo-server/assets/templates/common.html
@@ -21,7 +21,7 @@
 {{end}}
 
 {{define "ProjectNav"}}{{template "FlashMessages" .flashMessages}}<div class="clearfix" id="x-projnav">
-  {{if .pdoc.ProjectRoot}}{{if .pdoc.ProjectURL}}<a href="{{.pdoc.ProjectURL}}"><strong>{{.pdoc.ProjectName}}:</strong></a>{{else}}<strong>{{.pdoc.ProjectName}}:</strong>{{end}}{{else}}<a href="/-/go">Go:</a>{{end}}
+  {{if .pdoc.ProjectRoot}}{{if .pdoc.ProjectURL}}<a href="{{.pdoc.ProjectURL}}"><strong>{{.pdoc.ProjectName}}:</strong></a>{{else}}<strong>{{.pdoc.ProjectName}}:</strong>{{end}}{{else}}<a href="{{dynamicPath "/-/go"}}">Go:</a>{{end}}
   {{.pdoc.Breadcrumbs templateName}}
   {{if and .pdoc.Name (or templateName "pkg.html" templateName "cmd.html")}}
   <span class="pull-right">
@@ -100,7 +100,7 @@
 {{end}}
 <div id="x-pkginfo">
 {{with $.pdoc}}
-  <form name="x-refresh" method="POST" action="/-/refresh"><input type="hidden" name="path" value="{{.ImportPath}}"></form>
+  <form name="x-refresh" method="POST" action="{{dynamicPath "/-/refresh"}}"><input type="hidden" name="path" value="{{.ImportPath}}"></form>
   <p>{{if or .Imports $.importerCount}}Package {{.Name}} {{if .Imports}}imports <a href="?imports">{{.Imports|len}} packages</a> (<a href="?import-graph">graph</a>){{end}}{{if and .Imports $.importerCount}} and {{end}}{{if $.importerCount}}is imported by <a href="?importers">{{$.importerCount}} packages</a>{{end}}.{{end}}
   {{if not .Updated.IsZero}}Updated <span class="timeago" title="{{.Updated.Format "2006-01-02T15:04:05Z"}}">{{.Updated.Format "2006-01-02"}}</span>{{if or (equal .GOOS "windows") (equal .GOOS "darwin")}} with GOOS={{.GOOS}}{{end}}.{{end}}
   <a href="javascript:document.getElementsByName('x-refresh')[0].submit();" title="Refresh this page from the source.">Refresh now</a>.

--- a/gddo-server/assets/templates/home.html
+++ b/gddo-server/assets/templates/home.html
@@ -1,5 +1,5 @@
 {{define "Head"}}<title>GoDoc</title>
-{{/* <link type="application/opensearchdescription+xml" rel="search" href="/-/opensearch.xml?v={{fileHash "templates/opensearch.xml"}}"/> */}}{{end}}
+{{/* <link type="application/opensearchdescription+xml" rel="search" href="{{dynamicPath "/-/opensearch.xml?v={{fileHash "templates/opensearch.xml"}}"}}"/> */}}{{end}}
 
 {{define "Body"}}
 <div class="jumbotron">
@@ -9,7 +9,7 @@
 
 <p>GoDoc hosts documentation for <a href="https://golang.org/">Go</a> packages
 on Bitbucket, GitHub, Google Project Hosting and Launchpad.  Read the <a
-  href="/-/about">About Page</a> for information about adding packages to GoDoc
+  href="{{dynamicPath "/-/about"}}">About Page</a> for information about adding packages to GoDoc
 and more.
 
 <div class="row">
@@ -24,10 +24,10 @@ and more.
   <div class="col-sm-6">
     <h4>More Packages</h4>
     <ul class="list-unstyled">
-      <li><a href="/-/go">Go Standard Packages</a>
-      <li><a href="/-/subrepo">Go Sub-repository Packages</a>
-      <li><a href="https://golang.org/wiki/Projects">Projects @ go-wiki</a>
-      <li><a href="https://github.com/search?o=desc&amp;q=language%3Ago&amp;s=stars&amp;type=Repositories">Most stars</a>, 
+    <li><a href="{{dynamicPath "/-/go"}}">Go Standard Packages</a>
+    <li><a href="{{dynamicPath "/-/subrepo"}}">Go Sub-repository Packages</a>
+    <li><a href="https://golang.org/wiki/Projects">Projects @ go-wiki</a>
+    <li><a href="https://github.com/search?o=desc&amp;q=language%3Ago&amp;s=stars&amp;type=Repositories">Most stars</a>, 
         <a href="https://github.com/search?o=desc&amp;q=language%3Ago&amp;s=forks&amp;type=Repositories">most forks</a>, 
         <a href="https://github.com/search?o=desc&amp;q=language%3Ago&amp;s=updated&amp;type=Repositories">recently updated</a> on GitHub
     </ul>

--- a/gddo-server/assets/templates/layout.html
+++ b/gddo-server/assets/templates/layout.html
@@ -20,8 +20,8 @@
   </div>
   <div class="collapse navbar-collapse">
     <ul class="nav navbar-nav">
-        <li{{if equal "home.html" templateName}} class="active"{{end}}><a href="/">Home</a></li>
-        <li{{if equal "about.html" templateName}} class="active"{{end}}><a href="/-/about">About</a></li>
+      <li{{if equal "home.html" templateName}} class="active"{{end}}><a href="{{dynamicPath "/"}}">Home</a></li>
+        <li{{if equal "about.html" templateName}} class="active"{{end}}><a href="{{dynamicPath "/-/about"}}">About</a></li>
     </ul>
     <form class="navbar-nav navbar-form navbar-right" id="x-search" action="/" role="search"><input class="form-control" id="x-search-query" type="text" name="q" placeholder="Search"></form>
   </div>

--- a/gddo-server/config.go
+++ b/gddo-server/config.go
@@ -24,7 +24,7 @@ const (
 	githubClientIDEnvVar     = "GITHUB_CLIENT_ID"
 	githubClientSecretEnvVar = "GITHUB_CLIENT_SECRET"
 
-	getStaticURLEnvVar = "STATIC_URL"
+	getBaseURLEnvVar = "BASE_URL"
 )
 
 const (
@@ -35,7 +35,7 @@ const (
 	ConfigAssetsDir         = "assets"
 	ConfigRobotThreshold    = "robot"
 	ConfigGCELogName        = "gce_log_name"
-	ConfigStaticURL         = "static_url"
+	ConfigBaseURL           = "base_url"
 
 	// Database Config
 	ConfigDBServer      = "db-server"
@@ -114,7 +114,7 @@ func loadConfig(ctx context.Context, args []string) (*viper.Viper, error) {
 	v.BindEnv(ConfigGithubToken, githubTokenEnvVar)
 	v.BindEnv(ConfigGithubClientID, githubClientIDEnvVar)
 	v.BindEnv(ConfigGithubClientSecret, githubClientSecretEnvVar)
-	v.BindEnv(ConfigStaticURL, getStaticURLEnvVar)
+	v.BindEnv(ConfigBaseURL, getBaseURLEnvVar)
 
 	// Read from config.
 	if err := readViperConfig(ctx, v); err != nil {
@@ -177,7 +177,7 @@ func buildFlags() *pflag.FlagSet {
 	flags.String(ConfigGAERemoteAPI, "", "Remoteapi endpoint for App Engine Search. Defaults to serviceproxy-dot-${project}.appspot.com.")
 	flags.Float64(ConfigTraceSamplerFraction, 0.1, "Fraction of the requests sampled by the trace API.")
 	flags.Float64(ConfigTraceSamplerMaxQPS, 5, "Max number of requests sampled every second by the trace API.")
-	flags.String(ConfigStaticURL, "", "Custom Static URL used in templates for static resources")
+	flags.String(ConfigBaseURL, "", "Custom Base URL used in templates for static resources and package uris")
 
 	return flags
 }

--- a/gddo-server/template.go
+++ b/gddo-server/template.go
@@ -552,8 +552,11 @@ func parseTemplates(dir string, cb *httputil.CacheBusters, v *viper.Viper) (temp
 		"noteTitle":         noteTitleFn,
 		"relativePath":      relativePathFn,
 		"sidebarEnabled":    func() bool { return v.GetBool(ConfigSidebar) },
+		"dynamicPath": func(p string) string {
+			return strings.Join([]string{v.GetString(ConfigBaseURL), p}, "")
+		},
 		"staticPath": func(p string) string {
-			return strings.Join([]string{v.GetString(ConfigStaticURL), cb.AppendQueryParam(p, "v")}, "")
+			return strings.Join([]string{v.GetString(ConfigBaseURL), cb.AppendQueryParam(p, "v")}, "")
 		},
 	}
 	for _, set := range htmlSets {


### PR DESCRIPTION
This hopefully catches all URIs that don't have any support for non-subdomain
hosting of the gddo server.

Checking the following seems to suggest we've caught everything:

```
$ sift '\/-\/' gddo-server/assets/templates/ | grep -v -E '(static|dynamic)Path'
gddo-server/assets/templates/opensearch.xml:2:<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/">
gddo-server/assets/templates/opensearch.xml:7:    <Url type="application/x-suggestions+json" template="http://{{.}}/-/suggest?q={searchTerms}"/>
gddo-server/assets/templates/layout.html:2:<head profile="http://a9.com/-/spec/opensearch/1.1/">
gddo-server/assets/templates/tools.html:22:    <form name="x-lint" method="POST" action="https://go-lint.appspot.com/-/refresh"><input name="importPath" type="hidden" value="{{.pdoc.ImportPath}}"></form>
```

This now defines a `--base_url` / `BASE_URL` configuration value which is used
for static resources and dynamic pages. To achieve this we've defined an
additional template function:

```#go
// Returns a fully compueted Absolute URI based on `--base_url` / `BASE_URL`
// so that gddo server can be hosted on non-subdomains.
func dynamicPath(p string) string { ... }
```